### PR TITLE
fix: Windows os.chmod compatibility + init.py config save/parse consistency

### DIFF
--- a/agent_registry/core.py
+++ b/agent_registry/core.py
@@ -20,6 +20,7 @@ import json
 import os
 import re
 from pathlib import Path
+IS_WINDOWS = os.name == 'nt'
 from threading import Lock
 from typing import List, Dict, Tuple, Optional, Any
 
@@ -76,7 +77,8 @@ class RegistryCore:
         else:
             data_path = Path(get_root_path()) / "data"
             data_path.mkdir(parents=True, exist_ok=True)
-            os.chmod(data_path, 0o700)
+            if not IS_WINDOWS:
+                os.chmod(data_path, 0o700)
             file_storage_conf = {
                 'file.path': str(data_path / persistence_file),
                 'metadata.file': str(data_path / persistence_metadata_file),

--- a/agent_registry/init.py
+++ b/agent_registry/init.py
@@ -30,7 +30,7 @@ class InitCommand:
                 line = line.strip()
                 if line and '=' in line and not line.startswith('#'):
                     key, _, value = line.partition('=')
-                    config[key.strip()] = value.strip()
+                    config[key.strip().lower()] = value.strip()
         return config
 
     def init_command(self):
@@ -86,9 +86,10 @@ class InitCommand:
             config['signature_validation_enabled'] = default_signature
             print(f"Signature validation set to default: {default_signature}")
 
-        print("\nConfigure JWK certificate for registry signature verification:")
-        jwk_config = self.config_jwk_cert()
-        config.update(jwk_config)
+        if config['registry.sign.enabled'] == 'true':
+            print("\nConfigure JWK certificate for registry signature verification:")
+            jwk_config = self.config_jwk_cert()
+            config.update(jwk_config)
 
         default_approval = self.existing_config.get('agent_approval_enabled', 'false')
         current_approval = default_approval
@@ -287,6 +288,8 @@ class InitCommand:
 
         path_obj = Path(path)
         if not path_obj.exists():
+            if not required:
+                return True, ""
             return False, f"File does not exist: {path}"
 
         if not path_obj.is_file():
@@ -355,20 +358,36 @@ class InitCommand:
         config_dir = os.path.dirname(self.config_file)
         os.makedirs(config_dir, exist_ok=True)
 
-        existing_config = {}
         if os.path.exists(self.config_file):
+            updated_keys = set()
+            new_lines = []
             with open(self.config_file, 'r', encoding='utf-8') as f:
                 for line in f:
-                    line = line.strip()
-                    if line and '=' in line:
-                        key, _, value = line.partition('=')
-                        existing_config[key.strip()] = value.strip()
+                    stripped = line.strip()
+                    if stripped and '=' in stripped and not stripped.startswith('#'):
+                        key = stripped.split('=', 1)[0].strip()
+                        key_lower = key.lower()
+                        if key_lower in config and key_lower not in updated_keys:
+                            new_lines.append(f"{key}={config[key_lower]}\n")
+                            updated_keys.add(key_lower)
+                            continue
+                        if key_lower in updated_keys:
+                            continue
+                    else:
+                        if not line.endswith('\n'):
+                            line += '\n'
+                    new_lines.append(line)
 
-        existing_config.update(config)
+            for key, value in config.items():
+                if key not in updated_keys:
+                    new_lines.append(f"{key}={value}\n")
 
-        with open(self.config_file, 'w', encoding='utf-8') as f:
-            for key, value in existing_config.items():
-                f.write(f"{key}={value}\n")
+            with open(self.config_file, 'w', encoding='utf-8') as f:
+                f.writelines(new_lines)
+        else:
+            with open(self.config_file, 'w', encoding='utf-8') as f:
+                for key, value in config.items():
+                    f.write(f"{key}={value}\n")
 
         os.chmod(self.config_file, 0o600)
 
@@ -450,9 +469,12 @@ class InitCommand:
                     stripped = line.strip()
                     if stripped and '=' in stripped and not stripped.startswith('#'):
                         key = stripped.split('=', 1)[0].strip()
-                        if key in config:
-                            new_lines.append(f"{key}={config[key]}\n")
-                            updated_keys.add(key)
+                        key_lower = key.lower()
+                        if key_lower in config and key_lower not in updated_keys:
+                            new_lines.append(f"{key}={config[key_lower]}\n")
+                            updated_keys.add(key_lower)
+                            continue
+                        if key_lower in updated_keys:
                             continue
                     else:
                         if not line.endswith('\n'):

--- a/common/log/audit_logger.py
+++ b/common/log/audit_logger.py
@@ -28,6 +28,7 @@ from common.util.app_config import get_root_path, load_configs
 
 # File permissions: 600 -> owner read/write only, others no access
 FILE_PERMISSION_MODE = 0o600
+IS_WINDOWS = os.name == 'nt'
 
 
 class LogLevel:
@@ -78,7 +79,8 @@ class AuditLogger:
         parent_path = os.path.join(get_root_path(), "log", "audit")
         audit_log_dir = Path(parent_path)
         audit_log_dir.mkdir(parents=True, exist_ok=True)
-        os.chmod(audit_log_dir, 0o700)
+        if not IS_WINDOWS:
+            os.chmod(audit_log_dir, 0o700)
         self.log_file = os.path.join(parent_path, "audit.log")
         self.lock = threading.Lock()
 
@@ -153,7 +155,8 @@ class AuditLogger:
         # 4. Create new log file
         try:
             open(self.log_file, 'w').close()
-            os.chmod(self.log_file, FILE_PERMISSION_MODE)
+            if not IS_WINDOWS:
+                os.chmod(self.log_file, FILE_PERMISSION_MODE)
         except Exception as e:
             logger.error(f"Error: failed to create new log file: {e}")
 
@@ -164,7 +167,8 @@ class AuditLogger:
             with open(self.log_file, 'a', encoding='utf-8') as f:
                 f.write(json.dumps(log_entry, ensure_ascii=False) + '\n')
             # Ensure permissions (especially on newly created files)
-            os.chmod(self.log_file, FILE_PERMISSION_MODE)
+            if not IS_WINDOWS:
+                os.chmod(self.log_file, FILE_PERMISSION_MODE)
 
 
 audit_logger = AuditLogger()

--- a/common/log/logger_setup.py
+++ b/common/log/logger_setup.py
@@ -23,11 +23,13 @@ from pathlib import Path
 from loguru import logger
 
 from common.util.app_config import get_root_path
+IS_WINDOWS = os.name == 'nt'
 
 root_path = get_root_path()
 _LOG_DIR = Path(root_path) / "log"
 _LOG_DIR.mkdir(exist_ok=True)
-os.chmod(_LOG_DIR, 0o700)
+if not IS_WINDOWS:
+    os.chmod(_LOG_DIR, 0o700)
 
 LOG_FORMAT = (
     "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
@@ -61,7 +63,8 @@ def add_module_logger(module_prefix: str):
                 zf.write(source_file, arcname=Path(source_file).name)
 
             # Set permissions after compression
-            os.chmod(zip_file, 0o440)
+            if not IS_WINDOWS:
+                os.chmod(zip_file, 0o440)
 
             # Optionally remove original log file
             os.remove(source_file)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -386,10 +386,150 @@ class TestInitCommand(unittest.TestCase):
 
         with patch('builtins.input', side_effect=['', '']):
             with patch.object(init_cmd, 'validate_cert_path', return_value=(True, "")):
-                with patch.object(init_cmd, 'validate_file_permissions', return_value=(True, "")):
+               with patch.object(init_cmd, 'validate_file_permissions', return_value=(True, "")):
                     config = init_cmd.config_sign_cert()
 
                     self.assertEqual(config['sign_keyfile_password'], '/existing_sign_pwd')
+
+
+# ==================== Config Save/Parse Consistency Tests ====================
+
+class TestInitConfigFixes(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.config_file = os.path.join(self.temp_dir, "server.conf")
+
+    def tearDown(self):
+        if os.path.exists(self.config_file):
+            os.remove(self.config_file)
+        os.rmdir(self.temp_dir)
+
+    def _create_init_command(self):
+        init_cmd = InitCommand()
+        init_cmd.config_file = self.config_file
+        init_cmd.existing_config = {}
+        return init_cmd
+
+    def test_parse_config_file_lowercases_keys(self):
+        with open(self.config_file, 'w', encoding='utf-8') as f:
+            f.write("IP=127.0.0.1\n")
+            f.write("PORT=5000\n")
+            f.write("enable_https=true\n")
+
+        init_cmd = self._create_init_command()
+        config = init_cmd._parse_config_file(init_cmd.config_file)
+
+        self.assertIn('ip', config)
+        self.assertIn('port', config)
+        self.assertEqual(config['ip'], '127.0.0.1')
+        self.assertEqual(config['port'], '5000')
+        self.assertNotIn('IP', config)
+        self.assertNotIn('PORT', config)
+
+    def test_parse_config_file_mixed_case_keys(self):
+        with open(self.config_file, 'w', encoding='utf-8') as f:
+            f.write("Agent_Approval_Enabled=true\n")
+
+        init_cmd = self._create_init_command()
+        config = init_cmd._parse_config_file(init_cmd.config_file)
+
+        self.assertIn('agent_approval_enabled', config)
+        self.assertNotIn('Agent_Approval_Enabled', config)
+
+    def test_save_config_preserves_comments_and_blank_lines(self):
+        init_cmd = self._create_init_command()
+
+        original = (
+            "# Copyright header line\n"
+            "\n"
+            "# Listening IP\n"
+            "ip=127.0.0.1\n"
+            "#ssl_crl_file=etc/ssl/revocationlist.crl\n"
+            "enable_https=true\n"
+            "\n"
+            "agent_approval_enabled=false\n"
+        )
+        with open(self.config_file, 'w', encoding='utf-8') as f:
+            f.write(original)
+
+        init_cmd.save_config_to_file({'ip': '192.168.1.1'})
+
+        with open(self.config_file, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn('# Copyright header line', content)
+        self.assertIn('# Listening IP', content)
+        self.assertIn('#ssl_crl_file=etc/ssl/revocationlist.crl', content)
+        self.assertIn('ip=192.168.1.1', content)
+        self.assertNotIn('ip=127.0.0.1', content)
+        self.assertIn('\n\n', content)
+        self.assertIn('agent_approval_enabled=false', content)
+
+    def test_save_config_case_insensitive_key_match(self):
+        init_cmd = self._create_init_command()
+
+        with open(self.config_file, 'w', encoding='utf-8') as f:
+            f.write("IP=127.0.0.1\n")
+            f.write("PORT=5000\n")
+            f.write("enable_https=true\n")
+
+        init_cmd.save_config_to_file({'ip': '10.0.0.1', 'port': '8080'})
+
+        with open(self.config_file, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn('IP=10.0.0.1', content)
+        self.assertIn('PORT=8080', content)
+        self.assertEqual(content.count('10.0.0.1'), 1)
+        self.assertEqual(content.count('8080'), 1)
+        self.assertNotIn('127.0.0.1', content)
+        self.assertNotIn('5000', content)
+
+    def test_save_config_no_duplicate_keys(self):
+        init_cmd = self._create_init_command()
+
+        with open(self.config_file, 'w', encoding='utf-8') as f:
+            f.write("enable_https=false\n")
+            f.write("use_vectordb=False\n")
+            f.write("agent_approval_enabled=false\n")
+
+        init_cmd.save_config_to_file({'enable_https': 'true'})
+
+        with open(self.config_file, 'r', encoding='utf-8') as f:
+            lines = f.readlines()
+
+        https_lines = [l for l in lines if l.strip().startswith('enable_https')]
+        self.assertEqual(len(https_lines), 1)
+        self.assertIn('true', https_lines[0])
+
+        vectordb_lines = [l for l in lines if l.strip().startswith('use_vectordb')]
+        self.assertEqual(len(vectordb_lines), 1)
+        self.assertIn('False', vectordb_lines[0])
+
+    def test_save_persistence_config_case_insensitive(self):
+        persistence_file = os.path.join(self.temp_dir, "persistence.conf")
+
+        original = (
+            "# Persistence mode\n"
+            "PERSISTENCE.MODE=file\n"
+            "postgresql.host=localhost\n"
+        )
+        with open(persistence_file, 'w', encoding='utf-8') as f:
+            f.write(original)
+
+        init_cmd = InitCommand()
+        init_cmd.persistence_config_file = persistence_file
+        init_cmd.save_persistence_config_to_file({'persistence.mode': 'postgresql'})
+
+        with open(persistence_file, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn('PERSISTENCE.MODE=postgresql', content)
+        self.assertIn('postgresql.host=localhost', content)
+        self.assertIn('# Persistence mode', content)
+        self.assertEqual(content.count('postgresql'), 2)
+
+        os.remove(persistence_file)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #15, closes #17

## Changes

### 1. Windows os.chmod compatibility

Fix os.chmod calls that fail on Windows where Unix permission bits are not supported (audit_logger, logger_setup, core.py).

### 2. init.py config save/parse consistency

Fix several bugs in agent_registry/init.py:

- _parse_config_file: lowercase keys to match load_configs
- save_config_to_file: rewrite to preserve comments/blank lines, case-insensitive key matching, eliminate duplicate keys
- save_persistence_config_to_file: add case-insensitive matching and duplicate skipping
- init_command: skip JWK cert config when registry.sign.enabled=false
- validate_cert_path: allow non-existent files when required=False
- Add 6 test cases in tests/test_init.py (class TestInitConfigFixes)

## Testing

All 24 tests pass:
```
pytest tests/test_init.py -v -- 24 passed
```