### PR TITLE
Add PowerShell execution policy troubleshooting to GCP guide

### DIFF
--- a/docs/en/Registry Center GCP Containerized Deployment Guide.md
+++ b/docs/en/Registry Center GCP Containerized Deployment Guide.md
@@ -75,6 +75,8 @@ If not, run `gcloud auth login` — a browser window will open for you to sign i
 
 ### Step 3: Navigate to the Project Directory and Deploy
 
+Open PowerShell (right-click Start → "Windows PowerShell" or "Terminal"), then run:
+
 ```powershell
 cd <project-directory-path>
 .\deploy-all.ps1
@@ -84,6 +86,17 @@ cd <project-directory-path>
 > ```powershell
 > cd C:\Users\YourUsername\Desktop\registry-center
 > ```
+
+> **If running `.\deploy-all.ps1` fails with the error** "File ... cannot be loaded. The file ... is not digitally signed. You cannot run this script on the current system." / "UnauthorizedAccess", this is caused by PowerShell's Execution Policy, which by default blocks unsigned scripts. Choose one of the following solutions:
+> - **Option 1 (Recommended, permanent)**: Loosen the execution policy for your user account. Local scripts can run directly; only scripts downloaded from the internet require a signature.
+>   ```powershell
+>   Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+>   ```
+>   Then run `.\deploy-all.ps1` again.
+> - **Option 2 (one-time only)**: Bypass the execution policy for a single run without changing system settings.
+>   ```powershell
+>   powershell -ExecutionPolicy Bypass -File .\deploy-all.ps1
+>   ```
 
 You will be prompted to enter:
 1. **GCP Project ID** — the ID you noted down when creating your project

--- a/docs/zh/注册中心GCP容器化部署指南.md
+++ b/docs/zh/注册中心GCP容器化部署指南.md
@@ -75,6 +75,8 @@ gcloud auth list
 
 ### 第 3 步：进入项目目录并一键部署
 
+打开 PowerShell（右键开始菜单 → "Windows PowerShell" 或 "终端"），然后执行：
+
 ```powershell
 cd 项目目录路径
 .\deploy-all.ps1
@@ -84,6 +86,17 @@ cd 项目目录路径
 > ```powershell
 > cd C:\Users\<YourUsername>\Desktop\registry-center
 > ```
+
+> **如果运行 `.\deploy-all.ps1` 报错** "File ... cannot be loaded. The file ... is not digitally signed. You cannot run this script on the current system." / "UnauthorizedAccess"，这是 PowerShell 执行策略（Execution Policy）默认禁止运行未签名脚本导致的。两种解决方法任选其一：
+> - **方法一（推荐，永久生效）**：为当前用户放开执行策略，本地脚本可直接运行，仅网络下载的脚本才需要签名。
+>   ```powershell
+>   Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+>   ```
+>   执行后再运行 `.\deploy-all.ps1` 即可。
+> - **方法二（仅本次运行生效）**：不修改系统设置，单次绕过执行策略。
+>   ```powershell
+>   powershell -ExecutionPolicy Bypass -File .\deploy-all.ps1
+>   ```
 
 运行后会提示你输入：
 1. **GCP Project ID** — 就是前面创建项目时记下的那个 ID


### PR DESCRIPTION
docs: add PowerShell execution policy troubleshooting and open PowerShell hint to GCP deployment guide


## Description

This PR improves the GCP Containerized Deployment Guide (both Chinese and English versions) to help users avoid and resolve a common PowerShell error encountered when running the deploy script.

Changes include:
1. Added a hint at the beginning of Step 3 to instruct users to open PowerShell before running the deploy command.
2. Added troubleshooting guidance for the PowerShell Execution Policy error ("File ... cannot be loaded. The file ... is not digitally signed. You cannot run this script on the current system." / "UnauthorizedAccess"), with two solutions:
   - Option 1 (Recommended, permanent): `Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned`
   - Option 2 (one-time only): `powershell -ExecutionPolicy Bypass -File .\deploy-all.ps1`

Both the Chinese (`docs/zh/注册中心GCP容器化部署指南.md`) and English (`docs/en/Registry Center GCP Containerized Deployment Guide.md`) versions are updated consistently.

## Related Issue(s)

<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [ ] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [ ] I have added tests that prove my fix is effective or my feature works (if applicable)
- [x] I have added or updated documentation as needed
- [ ] New source files include the SPDX license header

## Additional Context

The PowerShell Execution Policy error is a very common issue for Windows users running the `deploy-all.ps1` script for the first time. By placing the troubleshooting directly in Step 3 (rather than only in the FAQ section), users can resolve the error immediately when they encounter it during deployment.