### PR TITLE
fix(signature): gate jku key fetch behind operator allowlist (fixes #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The Registry Center provides unified lifecycle management for **AgentCards** —
 | **Agent Approval** | Optional manual review workflow — agents start as `registered`, admins promote to `published` |
 | **Tag Management** | Independent tag entities with full CRUD, assignable to agents |
 | **TLS Security** | TLS 1.2/1.3 with strong cipher suites, mutual TLS client certificate verification |
-| **Signature Verification** | JWS-based AgentCard integrity checks (RS256, ES256), static JWK or dynamic `jku` lookup |
+| **Signature Verification** | JWS-based AgentCard integrity checks (RS256, ES256), static JWK or dynamic `jku` lookup. `jku` lookup is gated by an operator-configured host allowlist (`jwk_allowlist` in `etc/conf/server.conf`, or `REGISTRY_JWK_ALLOWLIST`); with no allowlist configured the `jku` path is disabled (fail closed) and only backend keys are used |
 | **Owner Isolation** | Per-agent ownership via TLS client certificate CN, strict or relaxed mode |
 | **Content Safety** | Prompt injection and high-risk skill blacklist filtering on registration |
 | **Rate Limiting** | Per-endpoint rate limits (configurable: 50–100 req/s, JWK endpoint: 10 req/s) with moving-window algorithm |

--- a/agent_registry/server.py
+++ b/agent_registry/server.py
@@ -84,7 +84,10 @@ def get_signature_validator() -> AgentCardSignatureValidator:
     global _signature_validator
     if _signature_validator is None:
         public_key_manager = PublicKeyManager()
-        jwk_fetcher = JWKFetcher(public_key_manager)
+        jwk_fetcher = JWKFetcher(
+            public_key_manager,
+            jwk_allowlist=config.get('jwk_allowlist', ''),
+        )
         validation_enabled = config.get('signature_validation_enabled', 'true').lower() == 'true'
         _signature_validator = AgentCardSignatureValidator(jwk_fetcher, signature_validation_enabled=validation_enabled)
     return _signature_validator

--- a/agent_registry/signature/jwk_fetcher.py
+++ b/agent_registry/signature/jwk_fetcher.py
@@ -15,7 +15,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import httpx
-from typing import Optional, Callable
+from typing import Optional, Callable, Set
+from urllib.parse import urlparse
 from jwt import PyJWK
 from loguru import logger
 from agent_registry.signature.models import JWK, JWKS
@@ -27,9 +28,52 @@ class JWKFetcher:
 
     REQUEST_TIMEOUT = 10
 
-    def __init__(self, public_key_manager: Optional[PublicKeyManager] = None):
+    def __init__(
+        self,
+        public_key_manager: Optional[PublicKeyManager] = None,
+        jwk_allowlist: Optional[str] = None,
+    ):
         self.session = httpx.AsyncClient(timeout=self.REQUEST_TIMEOUT)
         self.public_key_manager = public_key_manager
+        self.jwk_allowlist = self._parse_allowlist(jwk_allowlist or "")
+
+    @staticmethod
+    def _parse_allowlist(raw: str) -> Set[str]:
+        """Parse a comma-separated host allowlist into a normalized set."""
+        return {host.strip().lower() for host in raw.split(",") if host.strip()}
+
+    def _is_jku_host_allowed(self, jku: str) -> bool:
+        """
+        Check whether a jku URL host is permitted for key fetch.
+
+        The allowlist is the operator-declared trust boundary for signer-supplied
+        jku URLs (CWE-863). When no allowlist is configured the jku path fails
+        closed: no external key material is fetched from card-controlled input,
+        and only backend keys are used for verification.
+        """
+        if not self.jwk_allowlist:
+            logger.error(
+                "jku key fetch disabled: 'jwk_allowlist' is not configured. "
+                "Configure etc/conf/server.conf jwk_allowlist (or REGISTRY_JWK_ALLOWLIST) "
+                "to enable signer-supplied jku key lookup."
+            )
+            return False
+
+        try:
+            host = (urlparse(jku).hostname or "").lower()
+        except Exception as e:
+            logger.error(f"Failed to parse jku URL '{jku}': {e}")
+            return False
+
+        if not host:
+            logger.error(f"jku URL has no host: {jku}")
+            return False
+
+        if host in self.jwk_allowlist:
+            return True
+
+        logger.error(f"jku host '{host}' is not in the configured allowlist")
+        return False
 
     async def fetch_jwks(self, jku: str) -> Optional[JWKS]:
         """
@@ -43,6 +87,9 @@ class JWKFetcher:
         """
         try:
             logger.info(f"Fetching JWKS from: {jku}")
+
+            if not self._is_jku_host_allowed(jku):
+                return None
 
             if not jku.startswith('https://'):
                 logger.error(f"JKU must use HTTPS: {jku}")

--- a/etc/conf/server.conf
+++ b/etc/conf/server.conf
@@ -67,6 +67,14 @@ use_vectordb=False
 # Enable signature validation capability
 signature_validation_enabled=true
 
+# JWK allowlist for signer-supplied jku key lookup (CWE-863).
+# Comma-separated hostnames that may be used as jku in AgentCard signatures,
+# e.g.  jwk_allowlist=keys.example.com,keys.example.org
+# When empty (default), the jku path is DISABLED (fail closed): no external key
+# material is fetched from card-controlled URLs and only backend keys are used.
+# Overridable via REGISTRY_JWK_ALLOWLIST.
+jwk_allowlist=
+
 # Enable agent approval capability
 agent_approval_enabled=false
 

--- a/tests/test_jwk_allowlist.py
+++ b/tests/test_jwk_allowlist.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Tests for the JWK host allowlist (CWE-863 signer-controlled jku)."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agent_registry.signature.jwk_fetcher import JWKFetcher
+from agent_registry.signature.models import JWKS
+
+
+def _jwks_response_body() -> dict:
+    return {
+        "keys": [
+            {
+                "kty": "EC",
+                "kid": "test-key",
+                "use": "sig",
+                "alg": "ES256",
+                "crv": "P-256",
+                "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+                "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_fails_closed_when_no_allowlist_configured():
+    """No allowlist => jku path disabled, no HTTP request is made."""
+    fetcher = JWKFetcher(jwk_allowlist="")
+    fetcher.session.get = AsyncMock()
+
+    result = await fetcher.fetch_jwks("https://attacker.example.com/keys")
+
+    assert result is None
+    fetcher.session.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_host_not_in_allowlist():
+    """Host outside the allowlist is rejected before any HTTP request."""
+    fetcher = JWKFetcher(jwk_allowlist="keys.example.com")
+    fetcher.session.get = AsyncMock()
+
+    result = await fetcher.fetch_jwks("https://attacker.example.com/keys")
+
+    assert result is None
+    fetcher.session.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_non_https_even_when_host_allowed():
+    """HTTPS-only rule still applies after the allowlist check."""
+    fetcher = JWKFetcher(jwk_allowlist="keys.example.com")
+    fetcher.session.get = AsyncMock()
+
+    result = await fetcher.fetch_jwks("http://keys.example.com/keys")
+
+    assert result is None
+    fetcher.session.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_allows_host_in_allowlist():
+    """Allowed host => request proceeds and JWKS is parsed."""
+    fetcher = JWKFetcher(jwk_allowlist="keys.example.com")
+
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {"Content-Length": "256"}
+    response.json.return_value = _jwks_response_body()
+
+    fetcher.session.get = AsyncMock(return_value=response)
+
+    result = await fetcher.fetch_jwks("https://keys.example.com/jwks.json")
+
+    assert isinstance(result, JWKS)
+    assert len(result.keys) == 1
+    assert result.keys[0].kid == "test-key"
+    fetcher.session.get.assert_awaited_once_with("https://keys.example.com/jwks.json")
+
+
+@pytest.mark.asyncio
+async def test_fetch_allowlist_matches_host_only_ignoring_port_and_case():
+    """Port and case are ignored; the match is on the hostname alone."""
+    fetcher = JWKFetcher(jwk_allowlist="Keys.Example.COM")
+
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {"Content-Length": "256"}
+    response.json.return_value = _jwks_response_body()
+
+    fetcher.session.get = AsyncMock(return_value=response)
+
+    result = await fetcher.fetch_jwks("https://keys.example.com:8443/jwks.json")
+
+    assert isinstance(result, JWKS)
+    fetcher.session.get.assert_awaited_once_with("https://keys.example.com:8443/jwks.json")
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_malformed_jku():
+    """A jku with no hostname is rejected."""
+    fetcher = JWKFetcher(jwk_allowlist="keys.example.com")
+    fetcher.session.get = AsyncMock()
+
+    result = await fetcher.fetch_jwks("https:///missing-host")
+
+    assert result is None
+    fetcher.session.get.assert_not_called()
+
+
+def test_parse_allowlist_normalizes_whitespace_and_case():
+    fetcher = JWKFetcher(jwk_allowlist=" keys.example.com , Keys2.Example.org , ")
+
+    assert fetcher.jwk_allowlist == {"keys.example.com", "keys2.example.org"}


### PR DESCRIPTION
## Summary

Closes the core of #23 (CWE-863): signer-controlled `jku` in AgentCard signatures currently lets a forged card point the verifier at an attacker-hosted JWKS, and any HTTPS URL is fetchable (internal-HTTPS SSRF surface). The trust decision must not rest on attacker-supplied input.

This PR gates the `jku` path behind an operator-declared host allowlist and makes it **fail closed**:

- **New config `jwk_allowlist`** (`etc/conf/server.conf`, overridable via `REGISTRY_JWK_ALLOWLIST`): comma-separated hostnames permitted as `jku` targets.
- **`JWKFetcher.fetch_jwks`** now rejects any `jku` whose host is not on the allowlist *before* any HTTP request is made.
- **No allowlist configured ⇒ `jku` path disabled entirely.** Verification then uses only backend keys (the `PublicKeyManager` path), which is the operator-controlled trust anchor. This closes both CWE-863 and the remaining SSRF surface in one change.
- HTTPS-only and 1 MiB `Content-Length` caps (already present) remain in place.
- `AgentCardSignatureValidator` behavior is unchanged otherwise: backend-key-first, then (only if allowlisted) the `jku` path.

## Why fail-closed by default

The previous behavior fetched key material from any `https://` URL supplied by the card. Legitimate deployments that rely on `jku` can enumerate their key hosts in the allowlist; deployments that don't configure it lose nothing (backend keys still work) and gain a guarantee that card-controlled URLs are never contacted.

## Tests

7 new unit tests in `tests/test_jwk_allowlist.py` (fail-closed default, non-allowlisted host rejected with no HTTP call, HTTPS rule, port/case normalization, malformed URL, allowlist parsing). Full suite: **598 passed, 57 skipped** — no regressions.

## Config example

```ini
# etc/conf/server.conf
jwk_allowlist=keys.example.com,keys.example.org
```
