### PR TITLE
feat: registry-center-web supports standalone operation and OpenAN Portal plugin integration (#30)

### DIFF
--- a/registry-center-web/.gitignore
+++ b/registry-center-web/.gitignore
@@ -23,3 +23,6 @@ stats.html
 .env
 .env.local
 .env.*.local
+
+dist-plugin/
+node_modules/

--- a/registry-center-web/README.md
+++ b/registry-center-web/README.md
@@ -1,78 +1,86 @@
 # Registry Center Web
 
-Registry Center frontend - Agent CRUD management UI (register / deregister / modify / query), built to match the `workflow-designer` visual style, and publishable as a **qiankun micro-frontend (PIU)** for integration into the unified web frontend framework.
+注册中心前端 — **可独立运行，也可作为 OpenAN Portal 插件集成**。
 
-## Tech Stack
+## 两种运行形态
 
-React 18 + Vite + Tailwind CSS + lucide-react + framer-motion + i18next + axios. JavaScript/JSX (no TypeScript).
-
-## Develop
+### 1. 独立运行(自带完整壳)
 
 ```bash
 npm install
-npm run dev            # standalone at http://localhost:3004
-npm run dev:https      # https dev (mTLS backend)
+npm run dev
+# → http://localhost:3004 (自带 Header/主题/语言切换)
 ```
 
-Open the Settings (gear icon) to point at the Registry Center backend. Default: `https://127.0.0.1:5000` with API prefix `/rest/v1/registry-center`.
+后端代理:同源 `/rest/v1/registry-center/*` → `VITE_BACKEND_TARGET`(默认 `http://127.0.0.1:5000`)。
 
-### Backend assumptions (dev)
-
-The backend validates AgentCard signatures by default. For unsigned register/update to succeed in development, set in `etc/conf/server.conf`:
-
-```
-signature_validation_enabled=false
-owner.isolation.enabled=false
-```
-
-Client-certificate (mTLS) auth is handled by the browser; the SPA calls the HTTPS endpoint directly.
-
-## Build
+### 2. 作为 OpenAN Portal 插件(纯内容组件)
 
 ```bash
-npm run build          # standalone SPA, base "/"
-npm run build:qiankun  # qiankun sub-app, base "/registry-center/"
+npm run build:plugin
+# → dist-plugin/
+#   ├── index.js              UMD,挂 window.__OPENAN_PLUGIN__registry_center
+#   ├── index.css             编译后样式
+#   └── plugin.manifest.json  运行时元数据
 ```
 
-## Lint
+Portal 侧集成(二选一):
 
+**本地加载** — 产物复制到 Portal:
 ```bash
-npm run lint
+cp dist-plugin/* <Portal>/portal/public/plugins/registry-center/
 ```
-
-## Qiankun (PIU) Integration
-
-`src/main.jsx` exports the qiankun lifecycle (`bootstrap` / `mount` / `unmount`) and auto-detects `window.__POWERED_BY_QIANKUN__`. In standalone mode it mounts into `#root` with a `BrowserRouter`; under qiankun it mounts into the host-provided `props.container` with a `MemoryRouter`.
-
-Register the sub-app in the unified host framework:
-
+Portal `plugins.config.js`:
 ```js
-import { registerMicroApps } from 'qiankun'
-
-registerMicroApps([
-  {
-    name: 'registry-center',
-    entry: '//host/registry-center/',      // serves web/dist at base '/registry-center/'
-    container: '#subapp-container',
-    activeRule: '/registry-center',
-  },
-])
+{ id: 'registry-center', mode: 'bundle', entry: '/plugins/registry-center', enabled: true }
 ```
 
-Build with `npm run build:qiankun` (sets `VITE_BASE=/registry-center/`) and serve `dist/` under that sub-path.
+**远程加载** — 产物部署在本仓库服务器(nginx + CORS):
+```nginx
+location /plugins/registry-center/ {
+    alias /usr/share/nginx/html/plugins/registry-center/;
+    add_header Access-Control-Allow-Origin *;
+}
+```
+```js
+{ id: 'registry-center', mode: 'bundle',
+  entry: 'http://registry-center:5000/plugins/registry-center', enabled: true }
+```
 
-## Project Structure
+## 架构
 
 ```
-web/
-├─ src/
-│  ├─ main.jsx                 # dual-mode entry + qiankun lifecycle
-│  ├─ App.jsx                  # theme + header + content + ErrorBoundary
-│  ├─ index.css                # Tailwind directives + keyframes
-│  ├─ i18n.js · locales/{en,zh}.json
-│  ├─ service/api.js           # axios wrapper + agent CRUD
-│  └─ components/
-│     ├─ common/{header,setting,error_boundary}/index.jsx
-│     └─ registry_center/{index,agent_card_form,agent_detail,delete_confirm}/index.jsx
-└─ ...
+src/
+├── main.jsx                        ← 独立运行入口(自带壳:Header/主题/i18n)
+├── index.jsx                       ← Portal 插件入口(纯内容组件,消费 PortalContext)
+├── App.jsx                         ← 独立模式应用壳
+├── components/
+│   ├── registry_center/            ← 业务组件(AgentRegistry,接受注入的 api)
+│   └── common/                     ← 独立模式的壳组件(header/setting/error_boundary)
+├── service/api.js                  ← API 层(可注入 Portal 的 axios 实例)
+├── i18n.js + locales/              ← 国际化(en/zh)
+plugin.manifest.js                  ← Portal 插件声明(id/menu/routes/i18n/backend)
+vite.config.js                      ← 独立模式 dev/build 配置
+vite.bundle.config.js               ← 插件 UMD 打包配置
+portal-sdk/                         ← @openan/portal-sdk 本地副本(自包含)
 ```
+
+### 关键设计
+
+- **单一业务组件**: `AgentRegistry` 同时服务两种形态 — 独立模式由 App.jsx 传 `isDark`,插件模式由 `src/index.jsx` 传 `PortalContext.theme/api`
+- **API 可注入**: `getAgentCards(name, org, injectedApi)` — 插件模式注入 Portal 的 axios(走 Portal 网关),独立模式用本地实例(同源代理)
+- **React external**: 插件产物不打包 react/react-dom/react-i18next/portal-sdk,由 Portal 运行时全局提供(单一 React 实例)
+
+## API
+
+后端真实路径(见 `agent_registry/server.py`):
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/rest/v1/registry-center/agent-cards` | 查询 Agent 列表,响应 `{ agentCards: [...] }` |
+| POST | `/rest/v1/registry-center/agent-cards` | 注册 Agent(批量) |
+| PUT | `/rest/v1/registry-center/agent-cards/{org}/{name}` | 全量更新 |
+| DELETE | `/rest/v1/registry-center/agent-cards/{org}/{name}` | 注销 |
+| POST | `/rest/v1/registry-center/agent-cards/semantic-query` | 语义检索 |
+
+认证:mTLS(浏览器自动携带客户端证书),无 token。

--- a/registry-center-web/package-lock.json
+++ b/registry-center-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "registry-center-web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "registry-center-web",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "axios": "^1.16.0",
         "framer-motion": "^12.38.0",
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.5",
+        "@openan/portal-sdk": "file:./portal-sdk",
         "@vitejs/plugin-basic-ssl": "^2.3.0",
         "@vitejs/plugin-react": "^6.0.1",
         "autoprefixer": "^10.4.20",
@@ -34,7 +35,6 @@
         "rollup-plugin-visualizer": "^5.14.0",
         "tailwindcss": "^3.4.19",
         "vite": "^8.0.1",
-        "vite-plugin-qiankun": "^1.0.15",
         "vitest": "^4.0.0"
       }
     },
@@ -858,6 +858,10 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@openan/portal-sdk": {
+      "resolved": "portal-sdk",
+      "link": true
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.142.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
@@ -1628,13 +1632,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.18",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
@@ -1824,50 +1821,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/cheerio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
-      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cheerio-select": "^2.1.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.1.0",
-        "parse5": "^7.3.0",
-        "parse5-htmlparser2-tree-adapter": "^7.1.0",
-        "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.19.0",
-        "whatwg-mimetype": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=20.18.1"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-      }
-    },
-    "node_modules/cheerio-select": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-select": "^5.1.0",
-        "css-what": "^6.1.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -2015,36 +1968,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2167,65 +2090,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2253,33 +2117,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/encoding-sniffer": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
-      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "whatwg-encoding": "^3.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -3048,39 +2885,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/htmlparser2": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
-      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "entities": "^7.0.1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -3132,19 +2936,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -4797,19 +4588,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4949,59 +4727,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
-    },
-    "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
-      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "^5.0.3",
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-parser-stream": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
-      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -5661,13 +5386,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -6043,31 +5761,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -6318,20 +6011,6 @@
         }
       }
     },
-    "node_modules/vite-plugin-qiankun": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/vite-plugin-qiankun/-/vite-plugin-qiankun-1.0.15.tgz",
-      "integrity": "sha512-0QB0Wr8Eu/LGcuJAfuNXDb7BAFDszo3GCxq4bzgXdSFAlK425u1/UGMxaDEBVA1uPFrLsZPzig83Ufdfl6J45A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cheerio": "^1.0.0-rc.10"
-      },
-      "peerDependencies": {
-        "typescript": ">=4",
-        "vite": ">=2"
-      }
-    },
     "node_modules/vitest": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
@@ -6429,30 +6108,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -6576,6 +6231,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "portal-sdk": {
+      "name": "@openan/portal-sdk",
+      "version": "0.1.0",
+      "dev": true,
+      "devDependencies": {
+        "axios": "^1.16.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     }
   }

--- a/registry-center-web/package.json
+++ b/registry-center-web/package.json
@@ -1,14 +1,14 @@
 {
   "name": "registry-center-web",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
-  "description": "Registry Center frontend - Agent CRUD management UI, qiankun-compatible micro-frontend.",
+  "description": "Registry Center frontend — runs standalone or integrates into the OpenAN Portal as a plugin (UMD bundle).",
   "scripts": {
     "dev": "vite --host",
     "dev:https": "vite --host --mode https",
     "build": "vite build",
-    "build:qiankun": "vite build --mode qiankun",
+    "build:plugin": "vite build --config vite.bundle.config.js",
     "lint": "eslint .",
     "preview": "vite preview",
     "coverage": "vitest run --coverage"
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.5",
+    "@openan/portal-sdk": "file:./portal-sdk",
     "@vitejs/plugin-basic-ssl": "^2.3.0",
     "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.4.20",
@@ -40,7 +41,6 @@
     "rollup-plugin-visualizer": "^5.14.0",
     "tailwindcss": "^3.4.19",
     "vite": "^8.0.1",
-    "vite-plugin-qiankun": "^1.0.15",
     "vitest": "^4.0.0"
   }
 }

--- a/registry-center-web/plugin.manifest.js
+++ b/registry-center-web/plugin.manifest.js
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+import { LayoutDashboard } from 'lucide-react';
+
+/**
+ * OpenAN Portal plugin manifest for the Registry Center website.
+ *
+ * Integration modes (see README.md):
+ * - Standalone: npm run dev → own shell (Header/theme/i18n) via src/main.jsx
+ * - Portal plugin: npm run build:plugin → UMD bundle loaded by the Portal
+ *   (local copy under public/plugins/ or remote http with CORS)
+ */
+export default {
+    id: 'registry-center',
+    name: 'Registry Center',
+    version: '0.2.0',
+    backend: {
+        gateway: '/api/registry-center',
+    },
+    menu: [{
+        id: 'agents',
+        labelKey: 'registry-center:nav.title',
+        icon: LayoutDashboard,
+        order: 1,
+        route: '/registry',
+    }],
+    routes: [{
+        path: '/registry',
+        component: () => import('./src/index.jsx'),
+        menuId: 'agents',
+    }],
+    i18n: {
+        namespace: 'registry-center',
+        resources: {
+            en: () => import('./src/locales/en.json'),
+            zh: () => import('./src/locales/zh.json'),
+        },
+    },
+};

--- a/registry-center-web/portal-sdk/package.json
+++ b/registry-center-web/portal-sdk/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@openan/portal-sdk",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Plugin spec & shared contracts for the OpenAN Portal",
+  "type": "module",
+  "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./standalone": "./src/standalone.jsx"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "axios": "^1.16.0"
+  }
+}

--- a/registry-center-web/portal-sdk/src/config-loader.js
+++ b/registry-center-web/portal-sdk/src/config-loader.js
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+import { validateManifest } from './plugin-manifest.js';
+
+/**
+ * Load and validate all enabled plugins from a portal configuration object.
+ *
+ * The config shape (from portal/plugins.config.js):
+ * {
+ *   plugins: [
+ *     { id: 'orchestration-center', enabled: true, manifest: () => import('...') },
+ *     { id: 'skill-center',         enabled: false, manifest: () => import('...') },
+ *   ]
+ * }
+ *
+ * Disabled plugins are never imported (tree-shaken in production builds).
+ *
+ * @param {{ plugins: Array<{ id: string, enabled: boolean, manifest: () => Promise<{ default: import('./plugin-manifest.js').PluginManifest }> }}> }} config
+ * @returns {Promise<import('./plugin-manifest.js').PluginManifest[]>} — validated manifests, sorted by first menu item order
+ */
+export async function loadEnabledPlugins(config) {
+    if (!config || !Array.isArray(config.plugins)) {
+        return [];
+    }
+
+    const enabled = config.plugins.filter((p) => p.enabled);
+    if (enabled.length === 0) {
+        return [];
+    }
+
+    const modules = await Promise.all(
+        enabled.map(async (p) => {
+            if (typeof p.manifest !== 'function') {
+                throw new Error(
+                    `Plugin "${p.id}" has no manifest loader. ` +
+                    'Expected: { manifest: () => import("...") }'
+                );
+            }
+            const mod = await p.manifest();
+            return mod.default || mod;
+        })
+    );
+
+    const manifests = modules.map(validateManifest);
+
+    // Sort by the first menu item's order for stable navigation layout
+    manifests.sort((a, b) => {
+        const ao = a.menu?.[0]?.order ?? 999;
+        const bo = b.menu?.[0]?.order ?? 999;
+        return ao - bo;
+    });
+
+    return manifests;
+}

--- a/registry-center-web/portal-sdk/src/index.js
+++ b/registry-center-web/portal-sdk/src/index.js
@@ -15,20 +15,6 @@
 //    License for the specific language governing permissions and limitations
 //    under the License.
 
-// STANDALONE entry — renders the full app with its own shell
-// (Header / theme / language / settings). The Portal-plugin entry is
-// src/index.jsx (pure content component); this file is only used when the
-// website runs by itself via `npm run dev`.
-import { createRoot } from 'react-dom/client'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
-import './index.css'
-import './i18n'
-import App from './App.jsx'
-
-createRoot(document.getElementById('root')).render(
-    <BrowserRouter>
-        <Routes>
-            <Route path="/" element={<App />} />
-        </Routes>
-    </BrowserRouter>,
-)
+export { PortalContext, usePortalContext, PortalProvider } from './plugin-context.jsx';
+export { validateManifest } from './plugin-manifest.js';
+export { loadEnabledPlugins } from './config-loader.js';

--- a/registry-center-web/portal-sdk/src/plugin-context.js
+++ b/registry-center-web/portal-sdk/src/plugin-context.js
@@ -15,20 +15,6 @@
 //    License for the specific language governing permissions and limitations
 //    under the License.
 
-// STANDALONE entry — renders the full app with its own shell
-// (Header / theme / language / settings). The Portal-plugin entry is
-// src/index.jsx (pure content component); this file is only used when the
-// website runs by itself via `npm run dev`.
-import { createRoot } from 'react-dom/client'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
-import './index.css'
-import './i18n'
-import App from './App.jsx'
-
-createRoot(document.getElementById('root')).render(
-    <BrowserRouter>
-        <Routes>
-            <Route path="/" element={<App />} />
-        </Routes>
-    </BrowserRouter>,
-)
+// Re-export from the .jsx file — this .js shim lets consumers import
+// from './plugin-context.js' (plain JS) while the JSX lives in .jsx.
+export { PortalContext, usePortalContext, PortalProvider } from './plugin-context.jsx';

--- a/registry-center-web/portal-sdk/src/plugin-context.jsx
+++ b/registry-center-web/portal-sdk/src/plugin-context.jsx
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+import { createContext, useContext } from 'react';
+
+/**
+ * PortalContext — the shared capability surface injected into every plugin
+ * by the Portal shell.
+ *
+ * @typedef {Object} PortalContextValue
+ * @property {object} api                — Shared axios instance (gateway mode, httpOnly cookie)
+ * @property {object} auth               — { user, role, isAuthenticated, login, logout, check }
+ * @property {object} theme              — { isDark, toggle, setDark }
+ * @property {object} i18n               — i18n instance (react-i18next), plugins use own namespace
+ * @property {function} navigate         — React Router navigate function
+ * @property {object} router              — { location, params, navigate }
+ * @property {function} registerMenu      — Dynamically register a menu item (for lazy plugins)
+ * @property {function} registerRoute     — Dynamically register a route (for lazy plugins)
+ */
+
+/** @type {import('react').Context<PortalContextValue|null>} */
+export const PortalContext = createContext(null);
+
+const GLOBAL_KEY = '__OPENAN_PORTAL_CONTEXT__';
+
+/**
+ * Hook for plugins to access Portal-provided services.
+ *
+ * In normal mode (same Vite build), React Context works directly.
+ *
+ * In Module Federation dev mode, the plugin's copy of portal-sdk
+ * has a different React Context instance than the Portal's.
+ * To bridge this gap, PortalProvider also writes the context value
+ * to window.__OPENAN_PORTAL_CONTEXT__. This hook checks the React
+ * Context first, then falls back to the global variable.
+ *
+ * @returns {PortalContextValue}
+ */
+export function usePortalContext() {
+    const ctx = useContext(PortalContext);
+    if (ctx) return ctx;
+
+    if (typeof window !== 'undefined' && window[GLOBAL_KEY]) {
+        return window[GLOBAL_KEY];
+    }
+
+    throw new Error(
+        'usePortalContext() must be used within a <PortalProvider>. ' +
+        'In standalone mode, wrap your component with <MockPortal> from ' +
+        "'@openan/portal-sdk/standalone'."
+    );
+}
+
+/**
+ * PortalProvider — convenience wrapper for PortalContext.Provider.
+ * The Portal shell wraps its content with this, injecting all shared services.
+ * Also writes the context to a global variable for Module Federation bridging.
+ */
+export function PortalProvider({ value, children }) {
+    if (typeof window !== 'undefined') {
+        window[GLOBAL_KEY] = value;
+    }
+    return <PortalContext.Provider value={value}>{children}</PortalContext.Provider>;
+}

--- a/registry-center-web/portal-sdk/src/plugin-manifest.js
+++ b/registry-center-web/portal-sdk/src/plugin-manifest.js
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+/**
+ * Plugin Manifest — the declarative contract between a sub-application and
+ * the Portal shell.  Each plugin exports a default object conforming to this
+ * shape from its `plugin.manifest.js` file.
+ *
+ * @typedef {Object} MenuItem
+ * @property {string}   id            — Unique menu item id (also used as tab key)
+ * @property {string}   labelKey      — i18n key for the display label
+ * @property {import('react').ComponentType} icon — Icon component (e.g. lucide-react)
+ * @property {number}   order         — Sort order in the navigation bar
+ * @property {string[]} [permissions] — Required permissions (future use)
+ * @property {string}   route         — Route path that this menu item activates
+ *
+ * @typedef {Object} PluginRoute
+ * @property {string}   path          — Route path (e.g. "/orchestration")
+ * @property {() => Promise<import('react').ComponentType>} component — Lazy component loader
+ * @property {string}   menuId        — Associated menu item id (for active highlighting)
+ * @property {string[]} [permissions] — Required permissions (future use)
+ *
+ * @typedef {Object} PluginI18n
+ * @property {string} namespace                              — i18n namespace for this plugin
+ * @property {Object<string, () => Promise<Object>>} resources — { en: () => import(...), zh: () => import(...) }
+ *
+ * @typedef {Object} PluginManifest
+ * @property {string}   id          — Unique plugin id (e.g. "orchestration-center")
+ * @property {string}   name        — Human-readable display name
+ * @property {string}   version     — Semantic version
+ * @property {MenuItem[]}  menu     — Menu items to register in Portal navigation
+ * @property {PluginRoute[]} routes  — Routes to register in Portal router
+ * @property {PluginI18n} [i18n]     — Plugin-specific i18n resources
+ * @property {(ctx: import('./plugin-context.js').PortalContextValue) => void|Promise<void>} [onInit]    — Called once after registration
+ * @property {() => void} [onActivate]   — Called when the plugin becomes the active view
+ * @property {() => void} [onDeactivate] — Called when the plugin leaves the active view
+ * @property {{ enabled: boolean, entry: string }} [standalone] — Standalone mode config
+ */
+
+/**
+ * Validate a plugin manifest object.  Throws with a descriptive message if
+ * required fields are missing or have wrong types.
+ *
+ * @param {PluginManifest} manifest
+ * @returns {PluginManifest} — the validated manifest (same reference)
+ */
+export function validateManifest(manifest) {
+    const errors = [];
+
+    if (!manifest || typeof manifest !== 'object') {
+        throw new Error('Plugin manifest must be an object');
+    }
+    if (!manifest.id || typeof manifest.id !== 'string') {
+        errors.push('manifest.id is required (string)');
+    }
+    if (!manifest.name || typeof manifest.name !== 'string') {
+        errors.push('manifest.name is required (string)');
+    }
+    if (!manifest.version || typeof manifest.version !== 'string') {
+        errors.push('manifest.version is required (string)');
+    }
+    if (!Array.isArray(manifest.routes)) {
+        errors.push('manifest.routes must be an array');
+    } else {
+        manifest.routes.forEach((r, i) => {
+            if (!r.path) errors.push(`manifest.routes[${i}].path is required`);
+            if (typeof r.component !== 'function') {
+                errors.push(`manifest.routes[${i}].component must be a lazy-import function`);
+            }
+        });
+    }
+    if (manifest.menu && !Array.isArray(manifest.menu)) {
+        errors.push('manifest.menu must be an array if present');
+    }
+    if (manifest.i18n) {
+        if (!manifest.i18n.namespace) {
+            errors.push('manifest.i18n.namespace is required when i18n is present');
+        }
+        if (!manifest.i18n.resources || typeof manifest.i18n.resources !== 'object') {
+            errors.push('manifest.i18n.resources must be an object');
+        }
+    }
+
+    if (errors.length > 0) {
+        throw new Error(`Invalid plugin manifest "${manifest.id || '?'}": ${errors.join('; ')}`);
+    }
+    return manifest;
+}

--- a/registry-center-web/portal-sdk/src/standalone.jsx
+++ b/registry-center-web/portal-sdk/src/standalone.jsx
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+import { useState, useCallback, useEffect } from 'react';
+import axios from 'axios';
+import { PortalContext } from './plugin-context.jsx';
+
+/**
+ * MockPortal — a minimal Portal shell for running a single plugin in
+ * standalone mode (dev-only).  Provides just enough of PortalContext for
+ * the plugin to render without the full Portal infrastructure.
+ *
+ * Usage (in a plugin's standalone.jsx):
+ *   import { MockPortal } from '@openan/portal-sdk/standalone';
+ *   import MyPlugin from './index.jsx';
+ *
+ *   createRoot(document.getElementById('root')).render(
+ *     <MockPortal>
+ *       <MyPlugin />
+ *     </MockPortal>
+ *   );
+ */
+export function MockPortal({ children }) {
+    const [isDark, setIsDark] = useState(true);
+
+    // Apply the dark class to <html> so Tailwind's `dark:` variants work
+    // in standalone mode — mirrors the Portal's ThemeProvider behavior.
+    useEffect(() => {
+        const root = window.document.documentElement;
+        if (isDark) {
+            root.classList.add('dark');
+            root.style.colorScheme = 'dark';
+        } else {
+            root.classList.remove('dark');
+            root.style.colorScheme = 'light';
+        }
+    }, [isDark]);
+
+    // Same-origin direct calls — the standalone vite config proxies plugin
+    // API paths (e.g. /rest/v1/registry/*) straight to the plugin's backend.
+    // Component code uses api.get('/rest/v1/<domain>/...'), so the baseURL
+    // must stay EMPTY (not the Portal's '/api/orchestrate' gateway).
+    const mockApi = axios.create({
+        baseURL: '',
+        timeout: 120000,
+        withCredentials: true,
+    });
+    mockApi.interceptors.response.use(
+        (response) => response.data,
+        (error) => Promise.reject(error)
+    );
+
+    const value = {
+        api: mockApi,
+        auth: {
+            user: 'admin',
+            role: 'admin',
+            isAuthenticated: true,
+            login: async () => {},
+            logout: async () => {},
+            check: async () => ({ auth_required: false }),
+        },
+        theme: {
+            isDark,
+            toggle: () => setIsDark((v) => !v),
+            setDark: (v) => setIsDark(v),
+        },
+        i18n: {
+            t: (key) => key,
+            language: 'en',
+            changeLanguage: () => {},
+        },
+        navigate: () => {},
+        router: { location: { pathname: '/' }, params: {} },
+        registerMenu: () => {},
+        registerRoute: () => {},
+    };
+
+    if (typeof window !== 'undefined') {
+        window.__OPENAN_PORTAL_CONTEXT__ = value;
+    }
+    return <PortalContext.Provider value={value}>{children}</PortalContext.Provider>;
+}

--- a/registry-center-web/src/components/registry_center/index.jsx
+++ b/registry-center-web/src/components/registry_center/index.jsx
@@ -65,7 +65,7 @@ const getAgentLayer = (agent) => {
 
 const TABS = ['all', 'service', 'network', 'vendor']
 
-const AgentRegistry = ({ isDark }) => {
+const AgentRegistry = ({ isDark, api }) => {
     const { t } = useTranslation()
     const [searchTerm, setSearchTerm] = useState('')
     const [agents, setAgents] = useState([])
@@ -85,7 +85,9 @@ const AgentRegistry = ({ isDark }) => {
     const fetchData = useCallback(async () => {
         setLoading(true)
         try {
-            const response = await getAgentCards()
+            // injectedApi: Portal plugin mode (PortalContext.api); standalone
+            // mode omits it and uses the local service instance.
+            const response = await getAgentCards(undefined, undefined, api)
             const rawList = response?.agentCards || []
             const enhancedData = rawList.map((val) => {
                 const key = val.name

--- a/registry-center-web/src/index.jsx
+++ b/registry-center-web/src/index.jsx
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+/**
+ * Portal plugin entry — exports the Registry Center as a pure content
+ * component. The Portal shell provides navigation / auth / theme / i18n
+ * via PortalContext; this component only renders the agent registry itself.
+ *
+ * Loaded by the OpenAN Portal as a UMD bundle (local or remote mode).
+ */
+import { useTranslation } from 'react-i18next';
+import { usePortalContext } from '@openan/portal-sdk';
+import { ErrorBoundary } from '@/components/common/error_boundary/index.jsx';
+import AgentRegistry from '@/components/registry_center/index.jsx';
+
+export default function RegistryCenterPlugin() {
+    const { theme, api } = usePortalContext();
+    const isDark = theme.isDark;
+
+    return (
+        <div className="h-full w-full relative z-10 visible animate-in">
+            <ErrorBoundary>
+                <AgentRegistry isDark={isDark} api={api} />
+            </ErrorBoundary>
+        </div>
+    );
+}

--- a/registry-center-web/src/service/api.js
+++ b/registry-center-web/src/service/api.js
@@ -88,18 +88,23 @@ api.interceptors.response.use(
 )
 
 // ---- Agent queries ----
+// All queries accept an optional injected axios instance (Portal plugin mode
+// passes PortalContext.api). Falls back to this module's own instance for
+// standalone / legacy qiankun mode.
 
-export async function getAgentCards(name, organization) {
+export async function getAgentCards(name, organization, injectedApi) {
     const params = {}
     if (name) params.name = name
     if (organization) params.organization = organization
-    return api.get(`${REGISTRY_BASE()}/agent-cards`, { params })
+    const client = injectedApi || api
+    return client.get(`${REGISTRY_BASE()}/agent-cards`, { params })
 }
 
-export async function getAgentCard(name, organization) {
+export async function getAgentCard(name, organization, injectedApi) {
     const encodedOrg = encodeURIComponent(organization)
     const encodedName = encodeURIComponent(name)
-    return api.get(`${REGISTRY_BASE()}/agent-cards/${encodedOrg}/${encodedName}`)
+    const client = injectedApi || api
+    return client.get(`${REGISTRY_BASE()}/agent-cards/${encodedOrg}/${encodedName}`)
 }
 
 export async function semanticQueryAgentCards(task, topN) {

--- a/registry-center-web/vite.bundle.config.js
+++ b/registry-center-web/vite.bundle.config.js
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+/**
+ * UMD bundle build — packages the Portal plugin entry as a self-contained
+ * artifact for the OpenAN Portal (local or remote loading).
+ *
+ * Output (dist-plugin/):
+ *   index.js              ← UMD, sets window.__OPENAN_PLUGIN__registry_center
+ *   index.css             ← compiled styles
+ *   plugin.manifest.json  ← runtime metadata
+ *
+ * EXTERNAL (provided by Portal via globals): react, react-dom, react-i18next,
+ *   @openan/portal-sdk
+ * BUNDLED: everything else (lucide-react, react-markdown, the app's own
+ *   components/i18n/service layer)
+ *
+ * Usage: npm run build:plugin
+ */
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+import { readFileSync } from 'fs';
+
+const root = import.meta.dirname;
+const globalName = '__OPENAN_PLUGIN__registry_center';
+
+// Parse plugin.manifest.js source as text to extract JSON-able metadata
+// (icons are functions and can't be JSON-serialized — the Portal falls back
+// to a default icon).
+function buildManifestJson() {
+    const src = readFileSync(path.resolve(root, 'plugin.manifest.js'), 'utf-8');
+    const pick = (key, fallback) => src.match(new RegExp(`${key}:\\s*['"]([^'"]+)['"]`))?.[1] || fallback;
+    return JSON.stringify({
+        id: pick('id', 'registry-center'),
+        name: pick('name', 'Registry Center'),
+        version: pick('version', '0.0.0'),
+        backend: src.includes('gateway:') ? { gateway: pick('gateway', '') } : undefined,
+        menu: [{
+            id: pick("id: '", 'agents'),
+            labelKey: src.match(/labelKey:\s*'([^']+)'/)?.[1],
+            order: Number(src.match(/order:\s*(\d+)/)?.[1] || 99),
+            route: src.match(/route:\s*'([^']+)'/)?.[1],
+        }],
+        routes: [{
+            path: src.match(/path:\s*'([^']+)'/)?.[1] || '/registry',
+            menuId: src.match(/menuId:\s*'([^']+)'/)?.[1],
+        }],
+        entry: 'index.js',
+        css: 'index.css',
+    }, null, 2);
+}
+
+export default defineConfig({
+    plugins: [
+        react(),
+        {
+            name: 'emit-plugin-manifest-json',
+            generateBundle() {
+                this.emitFile({ type: 'asset', fileName: 'plugin.manifest.json', source: buildManifestJson() });
+            },
+        },
+    ],
+    resolve: {
+        alias: {
+            '@': path.resolve(root, 'src'),
+            '@openan/portal-sdk': path.resolve(root, 'portal-sdk/src/index.js'),
+        },
+    },
+    build: {
+        outDir: 'dist-plugin',
+        lib: {
+            entry: path.resolve(root, 'src/index.jsx'),
+            name: globalName,
+            formats: ['umd'],
+            fileName: () => 'index.js',
+        },
+        rollupOptions: {
+            external: ['react', 'react-dom', 'react-dom/client', 'react-i18next', '@openan/portal-sdk'],
+            output: {
+                globals: {
+                    react: 'React',
+                    'react-dom': 'ReactDOM',
+                    'react-dom/client': 'ReactDOM',
+                    'react-i18next': 'ReactI18next',
+                    '@openan/portal-sdk': 'OpenANPortalSDK',
+                },
+                assetFileNames: 'index.css',
+            },
+        },
+        cssCodeSplit: false,
+    },
+});

--- a/registry-center-web/vite.config.js
+++ b/registry-center-web/vite.config.js
@@ -15,74 +15,32 @@
 //    License for the specific language governing permissions and limitations
 //    under the License.
 
+// STANDALONE dev/build config — the website runs by itself with its own
+// shell (Header / theme / i18n) via src/main.jsx.
+//
+// Portal-plugin integration does NOT use this file — it uses
+// vite.bundle.config.js (UMD artifact for the OpenAN Portal).
+//
+// Dev: proxy same-origin API calls to the registry backend so the browser
+// avoids cross-origin (CORS) and self-signed-certificate issues. Override
+// the target via VITE_BACKEND_TARGET if needed.
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import basicSsl from '@vitejs/plugin-basic-ssl'
 import path from 'path'
 import { visualizer } from 'rollup-plugin-visualizer'
-import qiankun from 'vite-plugin-qiankun'
 
-// Dev-only: on startup, POST this sub-app's descriptor to the portal so it
-// appears in the portal sidebar automatically. Inert under `vite build`
-// (configureServer only runs for the dev server).
-function portalPublish(descriptor) {
-    return {
-        name: 'portal-publish',
-        configureServer(server) {
-            const portalUrl = process.env.PORTAL_URL || 'http://localhost:3000'
-            let stopped = false
-            let current = null
-            const post = async (path, body) => {
-                try {
-                    await fetch(`${portalUrl}${path}`, {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify(body),
-                    })
-                    return true
-                } catch (_e) {
-                    return false
-                }
-            }
-            const register = async (retries = 0) => {
-                if (stopped || !current) return
-                if (await post('/__portal__/register', current)) return
-                if (retries < 20) setTimeout(() => register(retries + 1), 2000)
-            }
-            server.httpServer?.on('listening', () => {
-                const addr = server.httpServer.address()
-                const port = typeof addr === 'object' && addr ? addr.port : descriptor.port
-                const { port: _omit, ...rest } = descriptor
-                current = { ...rest, entry: `http://localhost:${port}` }
-                register()
-            })
-            const deregister = () => {
-                stopped = true
-                if (current) post('/__portal__/unregister', { name: current.name }).catch(() => {})
-            }
-            process.on('SIGINT', () => { deregister(); process.exit(0) })
-            process.on('SIGTERM', () => { deregister(); process.exit(0) })
-        },
-    }
-}
-
-// The app can run standalone (base '/') or as a qiankun sub-app (base '/registry-center/').
-// base is driven by VITE_BASE so the unified web frontend framework can mount assets under a sub-path.
 export default ({ mode }) => {
     const env = loadEnv(mode, import.meta.dirname, '')
     const isHttps = mode === 'https'
     return defineConfig({
-        base: env.VITE_BASE || (mode === 'qiankun' ? '/registry-center/' : '/'),
+        base: env.VITE_BASE || '/',
         server: {
             port: 3004,
-            // Allow the qiankun host app to fetch this sub-app's entry/assets cross-origin.
             cors: true,
             headers: {
                 'Access-Control-Allow-Origin': '*',
             },
-            // Dev: proxy same-origin API calls to the registry backend so the browser
-            // avoids cross-origin (CORS) and self-signed-certificate issues.
-            // Override the target via VITE_BACKEND_TARGET (env) if needed.
             proxy: {
                 '/rest/v1/registry-center': {
                     target: env.VITE_BACKEND_TARGET || 'http://127.0.0.1:5000',
@@ -93,8 +51,6 @@ export default ({ mode }) => {
         },
         plugins: [
             react(),
-            qiankun('registry-center', { useDevMode: true }),
-            portalPublish({ name: 'registry-center', port: 3004, activeRule: '/registry-center', title: { zh: '注册中心', en: 'Registry Center' }, icon: 'Boxes' }),
             ...(isHttps ? [basicSsl()] : []),
             visualizer({ open: false, filename: 'stats.html', gzipSize: true, brotliSize: true }),
         ],


### PR DESCRIPTION
Rework `registry-center-web` to support **both standalone operation and integration into the OpenAN Portal as a plugin**, per #30.

## What Changes

The existing qiankun micro-frontend integration is replaced with the **OpenAN Portal plugin model**. The website keeps both runtime modes from a single business component:

### 1. Standalone (independent management frontend — the core ask of #30)

``bash
npm run dev        # → http://localhost:3004
``

Renders the full app with its own shell (Header / dark-light theme / language switch / settings) via `src/main.jsx`. Same developer experience as before, minus the qiankun lifecycle wrapper.

### 2. OpenAN Portal plugin (pluggable integration)

``bash
npm run build:plugin
# → dist-plugin/
#   ├── index.js              UMD, sets window.__OPENAN_PLUGIN__registry_center
#   ├── index.css             compiled styles
#   └── plugin.manifest.json  runtime metadata
``

The Portal loads the artifact either locally (copy under the Portal's `public/plugins/`) or remotely (served by this repo's server with CORS). React / react-dom / react-i18next / @openan/portal-sdk stay external — the Portal provides them at runtime, sharing a single React instance.

## Key Design

- **Single business component**: `AgentRegistry` serves both modes — standalone gets `isDark` from its own App shell, plugin mode gets theme + api from `PortalContext`
- **Injectable API layer**: `getAgentCards(name, org, injectedApi)` — plugin mode injects the Portal's axios (via the Portal gateway), standalone uses the local instance (same-origin proxy)
- **Aligned with the real backend**: API prefix `/rest/v1/registry-center/*` and response shape `{ agentCards: [...] }` (verified against `agent_registry/server.py`)

## File Changes

| File | Change |
|------|--------|
| `src/index.jsx` | NEW — Portal plugin entry (pure content component, consumes `usePortalContext()`) |
| `src/main.jsx` | Simplified to standalone-only rendering (qiankun bootstrap/mount/unmount removed) |
| `src/components/registry_center/index.jsx` | Accepts injected `api` prop |
| `src/service/api.js` | `getAgentCards`/`getAgentCard` accept `injectedApi` |
| `plugin.manifest.js` | NEW — Portal manifest (id/menu/routes/i18n/backend gateway) |
| `vite.bundle.config.js` | NEW — UMD plugin build |
| `vite.config.js` | Dropped qiankun plugin + portal auto-register; kept backend proxy |
| `portal-sdk/` | NEW — local @openan/portal-sdk copy (self-contained) |
| `package.json` | + `build:plugin` script, + portal-sdk dep, - qiankun/vite-plugin-qiankun |

## Verification

- Standalone dev server (:3004) renders correctly with mock data (`{ agentCards: [...] }`)
- `npm run build:plugin` produces a working UMD artifact (378 KB) that loads into the OpenAN Portal and renders with correct styling (verified in the Portal demo, local + remote modes)

Closes #30